### PR TITLE
o2m - add system realtime messages to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ OSC address pattern: /midi/heartbeat. Message body is OSC array of pairs <midi d
 	- channel_pressure: Body is (int32)channel, (int32)value
 	- poly_pressure: Body is (int32)channel, (int32)note, (int32)value
 	- program_change: Body is (int32)channel, (int32)program number
+        - clock: Body is empty
+        - start: Body is empty
+        - stop: Body is empty
+        - continue: Body is empty        
+        - active_sense: Body is empty                
 
 ## TODO
 * "all" devices should mean not only the devices that are found at the beginning of the run, but ALL the devices, even the ones that get plugged in later. (I think this is in now)

--- a/src/oscinprocessor.cpp
+++ b/src/oscinprocessor.cpp
@@ -56,13 +56,17 @@ void OscInProcessor::ProcessMessage(const osc::ReceivedMessage& message, const I
 
     regex addressRegex("/([[:alnum:]]+)/(([[:alnum:]]|_)+)");
     smatch match;
-        
+
     if (regex_match(addressPattern, match, addressRegex)) {
         cout << "Match (" << match[0] << ", " << match[1] << ", " << match[2] << endl;
         // We are interested in groups [1] and [2]. [1] -> device, [2] -> command / raw
         const string& outDevice = match[1];
         const string& command = match[2];
-        if (command == "raw") {
+
+        if (command == "clock") {
+          processClockMessage(outDevice);
+        }
+        else if (command == "raw") {
             processRawMessage(outDevice, message);
         }
         else if (command == "note_on") {
@@ -82,6 +86,17 @@ void OscInProcessor::ProcessMessage(const osc::ReceivedMessage& message, const I
         }
         else if (command == "poly_pressure") {
             processPolyPressureMessage(outDevice, message);
+        }
+        else if (command == "start") {
+          processStartMessage(outDevice);
+        }
+        else if (command == "continue") {
+          processContinueMessage(outDevice);
+        }
+        else if (command == "stop") {
+          processStopMessage(outDevice);
+        } else if (command == "active_sense") {
+          processActiveSenseMessage(outDevice);
         }
         else if (command == "program_change") {
             processProgramChangeMessage(outDevice, message);
@@ -182,6 +197,47 @@ void OscInProcessor::processNoteOnMessage(const string& outDevice, const osc::Re
     }
 
     MidiMessage midiMessage{ MidiMessage::noteOn(channel, note, (uint8)velocity) };
+    for (auto& output : m_outputs) {
+        output->send(midiMessage);
+    }
+}
+
+
+void OscInProcessor::processClockMessage(const string& outDevice)
+{
+  MidiMessage midiMessage{ MidiMessage::midiClock() };
+    for (auto& output : m_outputs) {
+        output->send(midiMessage);
+    }
+}
+
+void OscInProcessor::processStartMessage(const string& outDevice)
+{
+  MidiMessage midiMessage{ MidiMessage::midiStart() };
+    for (auto& output : m_outputs) {
+        output->send(midiMessage);
+    }
+}
+
+void OscInProcessor::processContinueMessage(const string& outDevice)
+{
+  MidiMessage midiMessage{ MidiMessage::midiContinue() };
+    for (auto& output : m_outputs) {
+        output->send(midiMessage);
+    }
+}
+
+void OscInProcessor::processStopMessage(const string& outDevice)
+{
+  MidiMessage midiMessage{ MidiMessage::midiStop() };
+    for (auto& output : m_outputs) {
+        output->send(midiMessage);
+    }
+}
+
+void OscInProcessor::processActiveSenseMessage(const string& outDevice)
+{
+  MidiMessage midiMessage{ MidiMessage() };
     for (auto& output : m_outputs) {
         output->send(midiMessage);
     }

--- a/src/oscinprocessor.h
+++ b/src/oscinprocessor.h
@@ -55,6 +55,11 @@ public:
     int getMidiOutId(int n);
 
 private:
+    void processClockMessage(const std::string& outDevice);
+    void processStartMessage(const std::string& outDevice);
+    void processContinueMessage(const std::string& outDevice);
+    void processStopMessage(const std::string& outDevice);
+    void processActiveSenseMessage(const std::string& outDevice);
     void processRawMessage(const std::string& outDevice, const osc::ReceivedMessage& message);
     void processNoteOnMessage(const std::string& outDevice, const osc::ReceivedMessage& message);
     void processNoteOffMessage(const std::string& outDevice, const osc::ReceivedMessage& message);


### PR DESCRIPTION
* Missing Reset - as this didn’t seem to be supported in JUCE.

OSC API:
        - `clock`: Body is empty
        - `start`: Body is empty
        - `stop`: Body is empty
        - `continue`: Body is empty
        - `active_sense`: Body is empty