### PR TITLE
Bind to all network interfaces by default.

### DIFF
--- a/src/oscin.cpp
+++ b/src/oscin.cpp
@@ -26,9 +26,12 @@
 
 using namespace std;
 
-OscIn::OscIn(int listenOscPort, osc::OscPacketListener *listener)
+OscIn::OscIn(bool local, int listenOscPort, osc::OscPacketListener *listener)
 {
-    m_socket = make_unique<UdpListeningReceiveSocket>(IpEndpointName("localhost", listenOscPort), listener);
+    if (local)
+        m_socket = make_unique<UdpListeningReceiveSocket>(IpEndpointName("localhost", listenOscPort), listener);        
+    else
+        m_socket = make_unique<UdpListeningReceiveSocket>(IpEndpointName(listenOscPort), listener);
 }
 
 

--- a/src/oscin.h
+++ b/src/oscin.h
@@ -29,7 +29,7 @@
 class OscIn
 {
 public:
-	OscIn(int listenOscPort, osc::OscPacketListener *listener);
+	OscIn(bool local, int listenOscPort, osc::OscPacketListener *listener);
     void run() {
         m_socket->Run();
     }

--- a/src/oscinprocessor.cpp
+++ b/src/oscinprocessor.cpp
@@ -27,9 +27,9 @@
 
 using namespace std;
 
-OscInProcessor::OscInProcessor(int oscListenPort)
+OscInProcessor::OscInProcessor(bool local, int oscListenPort)
 {
-    m_input = make_unique<OscIn>(oscListenPort, this);
+    m_input = make_unique<OscIn>(local, oscListenPort, this);
 }
 
 

--- a/src/oscinprocessor.h
+++ b/src/oscinprocessor.h
@@ -32,7 +32,7 @@
 
 class OscInProcessor : public osc::OscPacketListener {
 public:
-    OscInProcessor(int oscListenPort);
+    OscInProcessor(bool local, int oscListenPort);
 
     void prepareOutputs(const std::vector<std::string>& outputNames);
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,5 +1,5 @@
 #pragma once
-#define M2O_VERSION "0.1.0"
-#define O2M_VERSION "0.1.0"
+#define M2O_VERSION "0.2.0"
+#define O2M_VERSION "0.2.0"
 
 


### PR DESCRIPTION
Use -L argument to bin to local interface only.