### PR TITLE
Rename m2o OSC path pitch_bend_change to pitch_bend

### DIFF
--- a/src/midiinprocessor.cpp
+++ b/src/midiinprocessor.cpp
@@ -95,7 +95,7 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const MidiMes
         break;
 
     case 0xE0:
-        message_type = "pitch_bend_change";
+        message_type = "pitch_bend";
         assert(nBytes == 3);
         break;
 

--- a/src/midiinprocessor.cpp
+++ b/src/midiinprocessor.cpp
@@ -107,17 +107,17 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const MidiMes
         break;
 
     case 0xF1:
-        message_type = "syscommon_MTC";
+        message_type = "MTC";
         assert(nBytes == 2);
         break;
 
     case 0xF2:
-        message_type = "syscommon_song_position";
+        message_type = "song_position";
         assert(nBytes == 3);
         break;
 
     case 0xF3:
-        message_type = "syscommon_song_select";
+        message_type = "song_select";
         assert(nBytes == 2);
         break;
 
@@ -128,12 +128,12 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const MidiMes
         break;
 
     case 0xF6:
-        message_type = "syscommon_tune_request";
+        message_type = "tune_request";
         assert(nBytes == 1);
         break;
 
     case 0xF8:
-        message_type = "sysrt_timing_tick";
+        message_type = "clock";
         assert(nBytes == 1);
         break;
 
@@ -144,22 +144,22 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const MidiMes
         break;
 
     case 0xFA:
-        message_type = "sysrt_start_song";
+        message_type = "start";
         assert(nBytes == 1);
         break;
 
     case 0xFB:
-        message_type = "sysrt_continue_song";
+        message_type = "continue";
         assert(nBytes == 1);
         break;
 
     case 0xFC:
-        message_type = "sysrt_stop_song";
+        message_type = "stop";
         assert(nBytes == 1);
         break;
 
     case 0xFE:
-        message_type = "sysrt_active_sensing";
+        message_type = "active_sensing";
         assert(nBytes == 1);
         break;
 

--- a/src/oscinprocessor.cpp
+++ b/src/oscinprocessor.cpp
@@ -77,7 +77,7 @@ void OscInProcessor::ProcessMessage(const osc::ReceivedMessage& message, const I
             processContinueMessage(outDevice);
         } else if (command == "stop") {
             processStopMessage(outDevice);
-        } else if (command == "active_sense") {
+        } else if (command == "active_sensing") {
             processActiveSenseMessage(outDevice);
         } else if (command == "program_change") {
             processProgramChangeMessage(outDevice, message);


### PR DESCRIPTION
This maintains symmetry with the o2m path pitch_bend.