### PR TITLE
Sanitise OSC paths 

### DIFF
--- a/src/midicommon.cpp
+++ b/src/midicommon.cpp
@@ -41,6 +41,11 @@ string MidiCommon::getPortName() const
     return m_portName;
 }
 
+string MidiCommon::getNormalizedPortName() const
+{
+    return m_normalizedPortName;
+}
+
 int MidiCommon::getPortId() const
 {
     return m_stickyId;

--- a/src/midicommon.h
+++ b/src/midicommon.h
@@ -43,6 +43,7 @@ public:
     bool checkValid() const;
 
     std::string getPortName() const;
+    std::string getNormalizedPortName() const;
     int getPortId() const;
 
     static int getJuceMidiIdFromName(std::string portName);
@@ -50,6 +51,7 @@ public:
 protected:
     virtual void updateMidiDevicesNamesMapping() = 0;
     std::string m_portName;
+    std::string m_normalizedPortName;
     int m_juceMidiId;
     int m_stickyId;
     static bool nameInStickyTable(std::string portName);

--- a/src/midiin.cpp
+++ b/src/midiin.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include "midiin.h"
+#include "utils.h"
 
 using namespace std;
 
@@ -30,6 +31,9 @@ MidiIn::MidiIn(string portName, MidiInputCallback* midiInputCallback, bool isVir
     m_logger.debug("MidiIn constructor for {}", portName);
     updateMidiDevicesNamesMapping();
     m_portName = portName;
+    local_utils::safe_osc_string(portName);
+    m_normalizedPortName = portName;
+
     if (!nameInStickyTable(m_portName))
         m_stickyId = addNameToStickyTable(m_portName);
     else

--- a/src/midiinprocessor.cpp
+++ b/src/midiinprocessor.cpp
@@ -173,7 +173,7 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const juce::M
     stringstream path;
     string portNameWithoutSpaces(m_input->getPortName());
     int portId = m_input->getPortId();
-    local_utils::replace_chars(portNameWithoutSpaces, ' ', '_');
+    local_utils::safe_osc_string(portNameWithoutSpaces);
 
     // Was a template specified?
     if (m_useOscTemplate) {
@@ -181,7 +181,7 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const juce::M
         doTemplateSubst(templateSubst, portNameWithoutSpaces, portId, channel, message_type);
         path << templateSubst;
     } else {
-        path << "/midi/" << portId;
+        path << "/midi/" << portNameWithoutSpaces << "/" << portId;
         if (channel != 0xff) {
             path << "/" << (int)channel;
         }

--- a/src/midiinprocessor.cpp
+++ b/src/midiinprocessor.cpp
@@ -171,17 +171,15 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const juce::M
 
     // Prepare the OSC address
     stringstream path;
-    string portNameWithoutSpaces(m_input->getPortName());
+    string normalizedPortName(m_input->getNormalizedPortName());
     int portId = m_input->getPortId();
-    local_utils::safe_osc_string(portNameWithoutSpaces);
-
     // Was a template specified?
     if (m_useOscTemplate) {
         string templateSubst(m_oscTemplate);
-        doTemplateSubst(templateSubst, portNameWithoutSpaces, portId, channel, message_type);
+        doTemplateSubst(templateSubst, normalizedPortName, portId, channel, message_type);
         path << templateSubst;
     } else {
-        path << "/midi/" << portNameWithoutSpaces << "/" << portId;
+        path << "/midi/" << normalizedPortName << "/" << portId;
         if (channel != 0xff) {
             path << "/" << (int)channel;
         }
@@ -214,7 +212,7 @@ void MidiInProcessor::handleIncomingMidiMessage(MidiInput* source, const juce::M
     p << osc::EndMessage;
 
     // Dump the OSC message
-    m_logger.info("sending OSC: [{}] -> {}, {}", path.str(), portId, portNameWithoutSpaces);
+    m_logger.info("sending OSC: [{}] -> {}, {}", path.str(), portId, normalizedPortName);
     if (m_oscRawMidiMessage) {
         if (nBytes > 0) {
             m_logger.info("  <raw_midi_message>");

--- a/src/midiout.cpp
+++ b/src/midiout.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include "midiout.h"
+#include "utils.h"
 
 using namespace std;
 
@@ -30,6 +31,8 @@ MidiOut::MidiOut(string portName)
     m_logger.debug("MidiOut constructor for {}", portName);
     updateMidiDevicesNamesMapping();
     m_portName = portName;
+    local_utils::safe_osc_string(portName);
+    m_normalizedPortName = portName;
     if (!nameInStickyTable(m_portName))
         m_stickyId = addNameToStickyTable(m_portName);
     else

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,6 +33,40 @@ void replace_chars(string& str, char from, char to)
     replace_if(str.begin(), str.end(), [from, to](char c) { return c == from; }, to);
 }
 
+void downcase(string& str)
+{
+    transform(str.begin(), str.end(), str.begin(), ::tolower);
+}
+
+void safe_osc_string(string& str)
+{
+  /*ASCII characters not allowed in names of OSC paths
+    See: http://opensoundcontrol.org/spec-1_0
+    ' ' space             32
+    #   number sign       35
+    *   asterisk          42
+    ,   comma             44
+    /   forward slash     47
+    ?   question mark     63
+    [   open bracket      91
+    ]   close bracket     93
+    {   open curly brace  123
+    }   close curly brace 125
+  */
+
+    replace_chars(str, ' ', '_');
+    replace_chars(str, '#', '_');
+    replace_chars(str, '*', '_');
+    replace_chars(str, ',', '_');
+    replace_chars(str, '/', '_');
+    replace_chars(str, '?', '_');
+    replace_chars(str, '[', '_');
+    replace_chars(str, ']', '_');
+    replace_chars(str, '{', '_');
+    replace_chars(str, '}', '_');
+    downcase(str);
+}
+
 void logOSCMessage(const char* data, size_t size)
 {
     MonitorLogger::getInstance().trace("sent UDP message: ");

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,5 +27,7 @@
 
 namespace local_utils {
 void replace_chars(std::string& str, char from, char to);
+void downcase(std::string& str);
+void safe_osc_string(std::string& str);
 void logOSCMessage(const char* data, size_t size);
 }


### PR DESCRIPTION
Adhering to the OSC spec as described here:
http://opensoundcontrol.org/spec-1_0

The following characters are not allowed in the names of OSC paths:
    ' ' space             32
    #   number sign       35
    *   asterisk          42
    ,   comma             44
    /   forward slash     47
    ?   question mark     63
    [   open bracket      91
    ]   close bracket     93
    {   open curly brace  123
    }   close curly brace 125

We now replace these chars with underscores. Additionally the paths are
converted to lower case.