### PR TITLE
Fix issue #20. The -h option for o2m shows list of OSC messages

### DIFF
--- a/src/o2m.cpp
+++ b/src/o2m.cpp
@@ -66,7 +66,14 @@ void showVersion()
 
 int setup_and_parse_program_options(int argc, char* argv[], ProgramOptions& programOptions)
 {
-    cxxopts::Options options("o2m", "Bridges OSC to MIDI");
+    // Prepare the help string
+    string helpString("Bridges OSC to MIDI\no2m understands the following OSC messages:\n");
+    for (const auto& message: OscInProcessor::getKnownOscMessages()){
+        helpString += "- ";
+        helpString += message;
+        helpString += "\n";
+    }
+    cxxopts::Options options("o2m", helpString);
 
     options.add_options()
     ("l,list", "List output MIDI devices", cxxopts::value<bool>(programOptions.listPorts))

--- a/src/oscinprocessor.cpp
+++ b/src/oscinprocessor.cpp
@@ -451,6 +451,13 @@ int OscInProcessor::getMidiOutId(int n) const
     return m_outputs[n]->getPortId();
 }
 
+const std::vector<std::string> OscInProcessor::getKnownOscMessages()
+{
+    return std::vector<std::string>{"clock", "raw", "note_on", "note_off", "control_change",
+        "pitch_bend", "channel_pressure", "poly_pressure", "start", "continue", "stop",
+        "active_sensing", "program_change", "log_level", "log_to_osc"};
+}
+
 string OscInProcessor::getMidiOutName(int n) const
 {
     return m_outputs[n]->getPortName();

--- a/src/oscinprocessor.h
+++ b/src/oscinprocessor.h
@@ -58,6 +58,8 @@ public:
     std::string getNormalizedMidiOutName(int n) const;
     int getMidiOutId(int n) const;
 
+    static const std::vector<std::string> getKnownOscMessages();
+
 private:
     void send(const std::string& outDevice, const MidiMessage& msg);
     void processClockMessage(const std::string& outDevice);


### PR DESCRIPTION
The -h option for o2m lists the OSC messages that it understands.